### PR TITLE
Publish a GitHub release and attach concrete.phar on version-like tags

### DIFF
--- a/.github/workflows/create-release-notes
+++ b/.github/workflows/create-release-notes
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Generate a file containing the release notes.
+#
+# Required environment variables:
+# - GITHUB_WORKSPACE the path to the repository root directory
+# - GITHUB_REF the ref we are currently on (eg 'refs/tags/1.2.3')
+# - PATHS_FOR_RELEASE_NOTES the list of files/directories whose changes are included in the release notes
+#
+# Arguments
+# $1 the name of the file to be generated (if not absolute: relative to $GITHUB_WORKSPACE)
+
+set -o errexit
+set -o nounset
+
+CDPATH='' cd -- "$GITHUB_WORKSPACE"
+CURRENT_TAG_FOUND=n
+PREVIUOS_TAG=
+RELEASE_NOTES=
+for TAG in $(git tag --list --sort=-version:refname); do
+    if printf '%s' "$TAG" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+        if [ $CURRENT_TAG_FOUND = n ]; then
+            if [ "$TAG" = "${GITHUB_REF#refs/tags/}" ]; then
+                CURRENT_TAG_FOUND=y
+            fi
+        else
+            PREVIUOS_TAG="$TAG"
+            break
+        fi
+    fi
+done
+if [ $CURRENT_TAG_FOUND = n ]; then
+    echo 'Unable to build the release notes (current tag not found)'
+elif [ -z "$PREVIUOS_TAG" ]; then
+    echo 'Unable to build the release notes (previous release tag not found)'
+else
+    # shellcheck disable=SC2086
+    RELEASE_NOTES="$(git log --format='- %s' --no-merges --reverse "refs/tags/$PREVIUOS_TAG...$GITHUB_REF" -- $PATHS_FOR_RELEASE_NOTES)"
+    if [ -z "$RELEASE_NOTES" ]; then
+        printf 'Unable to build the release notes (empty commit list since %s)\n' "$PREVIUOS_TAG"
+    else
+        printf 'Detected release notes since %s:\n%s\n' "$PREVIUOS_TAG" "$RELEASE_NOTES"
+    fi
+fi
+if [ -z "$RELEASE_NOTES" ]; then
+    RELEASE_NOTES='n/a'
+fi
+printf '%s' "$RELEASE_NOTES" >"$1"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -82,43 +82,12 @@ jobs:
         run: printf '%s' "$VERSION" > version.txt
       - name: Build release notes
         if: env.VERSION != ''
-        run: |
-          CURRENT_TAG_FOUND=n
-          PREVIUOS_TAG=
-          RELEASE_NOTES=
-          for TAG in $(git tag --list --sort=-version:refname); do
-            if printf '%s' "$TAG" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
-              if test $CURRENT_TAG_FOUND = n; then
-                if test "$TAG" = "${GITHUB_REF#refs/tags/}"; then
-                  CURRENT_TAG_FOUND=y
-                fi
-              else
-                PREVIUOS_TAG="$TAG"
-                break
-              fi
-            fi
-          done
-          if test $CURRENT_TAG_FOUND = n; then
-            echo 'Unable to build the release notes (current tag not found)'
-          elif test -z "$PREVIUOS_TAG"; then
-            echo 'Unable to build the release notes (previous release tag not found)'
-          else
-            RELEASE_NOTES="$(git log --format='- %s' --no-merges --reverse "refs/tags/$PREVIUOS_TAG...$GITHUB_REF" -- $PATHS_FOR_RELEASE_NOTES)"
-            if test -z "$RELEASE_NOTES"; then
-              printf 'Unable to build the release notes (empty commit list since %s)\n' "$PREVIUOS_TAG"
-            else
-              printf 'Detected release notes since %s:\n%s\n' "$PREVIUOS_TAG" "$RELEASE_NOTES"
-            fi
-          fi
-          if test -z "$RELEASE_NOTES"; then
-            RELEASE_NOTES='n/a'
-          fi
-          printf '%s' "$RELEASE_NOTES" >new-release-notes.txt
+        run: ./.github/workflows/create-release-notes release-notes.txt
       - name: Publish release
         if: env.VERSION != ''
         uses: softprops/action-gh-release@v1
         with:
-          body_path: new-release-notes.txt
+          body_path: release-notes.txt
           draft: false
           prerelease: ${{ env.PRERELEASE }}
           files: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,129 @@
+name: Create GitHub release
+
+on:
+  create:
+    tags:
+      - "*[0-9]+.[0-9]+.[0-9]*"
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    env:
+      # Check the changes in these files/directories to build automatically the release notes
+      PATHS_FOR_RELEASE_NOTES: "box.json.dist composer.json bin/ src/"
+      # Its value will be set by the action (if release-like tag is created)
+      VERSION: ""
+      # Its value will be set by the action (if release-like tag is created)
+      PRERELEASE: ""
+      # The version of PHP to be used here
+      INSTALLER_PHP_VERSION: '7.3'
+      # The minimum PHP version the built phar should support
+      PHAR_PHP_VERSION: '7.1'
+      # The version of Box to be used
+      BOX_VERSION: 3.13.0
+    steps:
+      - name: Check tag format
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
+        run: |
+          VERSION="$(printf '%s' "$GITHUB_REF" | sed -E 's/^refs\/tags\/v?([0-9]+\.[0-9]+\.[0-9]+.*)$/\1/')"
+          if printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]'; then
+            case "$VERSION" in
+              *dev* | *snap* | *[Aa]* | *[Bb]* | *[Rr][Cc]*)
+                PRERELEASE=true
+                ;;
+              *)
+                PRERELEASE=false
+                ;;
+            esac
+            printf 'The tag %s is for version %s\n' "${GITHUB_REF#refs/tags/}" "$VERSION"
+            printf 'Pre-release: %s\n' "$PRERELEASE"
+            printf 'VERSION=%s\n' "$VERSION" >> "$GITHUB_ENV"
+            printf 'PRERELEASE=%s\n' "$PRERELEASE" >> "$GITHUB_ENV"
+          else
+            printf 'The ref %s is not for a version\n' "$GITHUB_REF"
+          fi
+      - name: Checkout
+        if: env.VERSION != ''
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup PHP
+        if: env.VERSION != ''
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.INSTALLER_PHP_VERSION }}
+          tools: composer:v2
+          coverage: none
+          ini-values: phar.readonly=0
+      - name: Configure environment
+        if: env.VERSION != ''
+        run: composer config platform.php "$PHAR_PHP_VERSION"
+      - name: Install Composer dependencies
+        if: env.VERSION != ''
+        run: composer update --no-dev --no-progress --optimize-autoloader --ansi --no-interaction --no-cache
+      - name: Download Box
+        if: env.VERSION != ''
+        run: curl -Lf -o box.phar "https://github.com/box-project/box/releases/download/$BOX_VERSION/box.phar"
+      - name: Create the PHAR file
+        if: env.VERSION != ''
+        run: php box.phar compile --ansi --no-interaction
+      - name: Check if the PHAR file works
+        if: env.VERSION != ''
+        run: ./concrete.phar list --ansi
+      - name: Create the signature file
+        if: env.VERSION != ''
+        run: |
+          HASH="$(sha384sum concrete.phar | cut -f1 -d' ')"
+          printf 'Calculated signature: %s\n' "$HASH"
+          printf '%s' "$HASH" > concrete.sig
+      - name: Create the version file
+        if: env.VERSION != ''
+        run: printf '%s' "$VERSION" > version.txt
+      - name: Build release notes
+        if: env.VERSION != ''
+        run: |
+          CURRENT_TAG_FOUND=n
+          PREVIUOS_TAG=
+          RELEASE_NOTES=
+          for TAG in $(git tag --list --sort=-version:refname); do
+            if printf '%s' "$TAG" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+              if test $CURRENT_TAG_FOUND = n; then
+                if test "$TAG" = "${GITHUB_REF#refs/tags/}"; then
+                  CURRENT_TAG_FOUND=y
+                fi
+              else
+                PREVIUOS_TAG="$TAG"
+                break
+              fi
+            fi
+          done
+          if test $CURRENT_TAG_FOUND = n; then
+            echo 'Unable to build the release notes (current tag not found)'
+          elif test -z "$PREVIUOS_TAG"; then
+            echo 'Unable to build the release notes (previous release tag not found)'
+          else
+            RELEASE_NOTES="$(git log --format='- %s' --no-merges --reverse "refs/tags/$PREVIUOS_TAG...$GITHUB_REF" -- $PATHS_FOR_RELEASE_NOTES)"
+            if test -z "$RELEASE_NOTES"; then
+              printf 'Unable to build the release notes (empty commit list since %s)\n' "$PREVIUOS_TAG"
+            else
+              printf 'Detected release notes since %s:\n%s\n' "$PREVIUOS_TAG" "$RELEASE_NOTES"
+            fi
+          fi
+          if test -z "$RELEASE_NOTES"; then
+            RELEASE_NOTES='n/a'
+          fi
+          printf '%s' "$RELEASE_NOTES" >new-release-notes.txt
+      - name: Publish release
+        if: env.VERSION != ''
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: new-release-notes.txt
+          draft: false
+          prerelease: ${{ env.PRERELEASE }}
+          files: |
+            concrete.phar
+            concrete.sig
+            version.txt
+          name: v${{ env.VERSION }}
+          fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-.DS_Store
-.idea
-vendor
+.phpunit.result.cache
+box.json
+box.phar
 build
 composer.lock
-.phpunit.result.cache
+concrete.phar
+concrete.sig
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+.idea
 .phpunit.result.cache
 box.json
 box.phar
@@ -5,4 +7,6 @@ build
 composer.lock
 concrete.phar
 concrete.sig
+release-notes.txt
 vendor
+version.txt

--- a/README.md
+++ b/README.md
@@ -7,8 +7,34 @@
 A command line utility for working with Concrete CMS.
 
 ## Installation
-### Global Installation
-The concrete console cli tool is meant to be installed globally with composer
+
+### As a PHAR file
+
+The latest version of the console cli tool is available at the following address:
+
+https://github.com/concrete5/console/releases/latest/download/concrete.phar
+
+#### Installation on Posix Systems
+
+You simply have to download it and make it executable:
+
+```sh
+curl -L -o /usr/local/bin/concrete https://github.com/concrete5/console/releases/latest/download/concrete.phar
+chmod +x /usr/local/bin/concrete
+```
+
+#### Installation on Windows Systems
+
+You can download the `concrete.phar` file in a directory listed in your `PATH` environment variable (for example: `C:\Windows\System32`),
+and create a `concrete.bat` file in the same directory with the following contents:
+
+```batch
+@php "%~dpn0.phar" %*
+```
+
+### With composer
+
+The concrete console cli tool can also be installed globally with composer
 
     composer global require concrete5/console
     

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,0 +1,45 @@
+{
+    "output": "./concrete.phar",
+    "git-tag": "concrete_version",
+    "force-autodiscovery": true,
+    "finder": [
+        {
+            "in": "art"
+        },
+        {
+            "in": "vendor",
+            "notName": [
+                "*.dist",
+                "*.md",
+                "*.neon",
+                "*.txt",
+                "appveyor.yml",
+                "build.xml",
+                "CodeSniffer.conf.*",
+                "composer.json",
+                "composer.lock",
+                "LICENSE",
+                "Makefile",
+                "phive.xml",
+                "phpbench.json",
+                "phpcs.xml",
+                "phpcs.xsd",
+                "phpunit.xml",
+                "psalm.xml",
+                "README"
+            ],
+            "exclude": [
+                "bin",
+                "docs",
+                "examples",
+                "test",
+                "tests",
+                "Tests"
+            ]
+        }
+    ],
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\Php",
+        "KevinGH\\Box\\Compactor\\Json"
+    ]
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -41,7 +41,9 @@ class Application extends SillyApplication
 
     public function __construct(Container $container)
     {
-        parent::__construct('Concrete Console', '0.1');
+        // This value will be replaced automatically when building the phar file.
+        $version = '@concrete_version@';
+        parent::__construct('Concrete Console', $version === '@concrete_' . 'version@' ? '' : ltrim($version, 'v'));
         $this->useContainer($container, true, true);
     }
 


### PR DESCRIPTION
Same as #11 except that:

- we create `concrete.phar` instead of `ccm.phar`
- we also attach to the release a `version.txt` file (containing the version) and a `concrete.sig` file (containing the sha-384 hash of the phar)

The `version.txt` file can be used to check the latest available version (by fetching  https://github.com/concrete5/console/releases/latest/download/version.txt).
The `concrete.sig` file can be used to check the downloaded `concrete.phar` file.

For an example: see https://github.com/mlocati/console/actions/runs/1267423664 and its result https://github.com/mlocati/console/releases/tag/0.7.2

PS: Closes #14