### PR TITLE
Remove duplicated requirement about helpers.php file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,7 @@
   "autoload-dev": {
     "psr-4": {
       "Concrete\\Console\\": "tests/"
-    },
-    "files": [
-      "helpers.php"
-    ]
+    }
   },
   "require-dev": {
     "ext-simplexml": "*",


### PR DESCRIPTION
It's already in the `require` section: no needs to have it in the `require-dev` too