### PR TITLE
Add missing .concrete/index.maintenance.php to PHAR

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -7,6 +7,12 @@
             "in": "art"
         },
         {
+            "in": ".concrete",
+            "name": [
+                "index.maintenance.php"
+            ]   
+        },
+        {
             "in": "vendor",
             "notName": [
                 "*.dist",


### PR DESCRIPTION
The built concrete.phar is missing the `./concrete/index.maintenance.php` file.

Let's add it.