### PR TITLE
Use an absolute URI to locate the psalm schema

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     phpVersion="7.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    xsi:schemaLocation="https://getpsalm.org/schema/config https://psalm.dev/schema/config"
 >
     <stubs>
         <file name=".psalm/stubs/Composer/Semver/Comparator.phpstub" />


### PR DESCRIPTION
We don't currently have psalm as a dev dependency, so the schema is not available locally