### PR TITLE
Allow commands to override the default --instance option

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -76,17 +76,6 @@ class Application extends SillyApplication
         return parent::doRun($input, $output);
     }
 
-    protected function getDefaultInputDefinition()
-    {
-        $definition = parent::getDefaultInputDefinition();
-
-        $definition->addOptions([
-            new InputOption('--instance', '-I', InputOption::VALUE_REQUIRED, 'Specify the concrete5 directory', '.'),
-        ]);
-
-        return $definition;
-    }
-
     public function getHelp()
     {
         $artWidth = 42;

--- a/src/Command/Backup/BackupCommand.php
+++ b/src/Command/Backup/BackupCommand.php
@@ -90,8 +90,8 @@ class BackupCommand extends Command
      */
     public static function register(Container $container, Application $console): void
     {
-        $console
-            ->command(
+        static::command(
+                $console,
                 'backup:backup [filename] [--skip-core] [--temp] [--dir=]',
                 self::class,
                 ['backup']

--- a/src/Command/Backup/InspectCommand.php
+++ b/src/Command/Backup/InspectCommand.php
@@ -85,7 +85,7 @@ class InspectCommand extends Command
 
     public static function register(Container $container, Application $console): void
     {
-        $console->command('backup:inspect backupfile [-r|--manifest-only] [--ls=]', self::class)
+        self::command($console, 'backup:inspect backupfile [-r|--manifest-only] [--ls=]', self::class)
             ->descriptions('Inspects a Concrete installation backup', [
                 'backupfile' => 'The path to the backup file to inspect',
                 '--manifest-only' => 'Output the raw manifest json, combine with <info>jq</> command.',

--- a/src/Command/Backup/RestoreCommand.php
+++ b/src/Command/Backup/RestoreCommand.php
@@ -86,8 +86,8 @@ class RestoreCommand extends Command
 
     public static function register(Container $container, Application $console): void
     {
-        $console
-            ->command(
+        self::command(
+                $console,
                 'backup:restore backupFile [-D|--dryrun] 
                         [--skip-db] [--skip-core] [--skip-packages] [--skip-config] [--skip-files] [--skip-application] 
                         [--skip-index] [--skip-database] [--reload-fpm-command=]',

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Concrete\Console\Command;
 
+use Concrete\Console\Application;
 use Concrete\Console\Concrete\Connection\ApplicationEnabledConnectionInterface;
 use Concrete\Console\Concrete\Connection\ConnectionAwareInterface;
 use Concrete\Console\Concrete\Connection\ConnectionAwareTrait;
@@ -12,6 +13,7 @@ use Concrete\Console\Installation\InstallationAwareInterface;
 use Concrete\Console\Installation\InstallationAwareTrait;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
+use Silly\Command\Command as SillyCommand;
 
 abstract class Command implements
     ContainerAwareInterface,
@@ -28,6 +30,21 @@ abstract class Command implements
     use InstallationAwareTrait;
 
     /**
+     * Additional options to add separate from declared commands
+     *
+     * @var array<int, array{long: string, short: string, description: string, default: mixed, optional: boolean}>
+     */
+    protected static $extendedOptions = [
+        [
+            'long' => 'instance',
+            'short' => 'I',
+            'description' => 'Specify the concrete5 directory',
+            'default' => '.',
+            'optional' => true,
+        ]
+    ];
+
+    /**
      * @throws \Concrete\Console\Exception\Installation\VersionMismatch
      */
     public function getApplication(): \Concrete\Core\Application\Application
@@ -38,5 +55,52 @@ abstract class Command implements
         }
 
         return $connection->getApplication();
+    }
+
+    /**
+     * Static function for resolving the command instance with $extendedOptions included.
+     *
+     * @param Application $console
+     * @param string $expression
+     * @param string|callable $callable
+     * @param array $aliases
+     *
+     * @return SillyCommand
+     */
+    public static function command(
+        Application $console,
+        string $expression,
+        $callable,
+        array $aliases = []
+    ): SillyCommand {
+        $extension = [];
+        $descriptions = [];
+        $defaults = [];
+        foreach (static::$extendedOptions as $option) {
+            [
+                'long' => $long,
+                'short' => $short,
+                'description' => $description,
+                'default' => $default,
+                'optional' => $optional
+            ] = $option;
+
+            // Resolve the extension string
+            $optionalAddition = $optional ? '=' : '';
+            $shortFlag = $short ? "-{$short}|" : '';
+            $longFlag = "--{$long}{$optionalAddition}";
+            $extension[] = "[{$shortFlag}{$longFlag}]";
+
+            // resolve defaults and descriptions
+            $defaults[$long] = $default;
+            $descriptions['--' . $long] = $description;
+        }
+
+        $extension = $extension ? ' ' . implode(' ', $extension) : '';
+
+        // Create a new command with our extension string added
+        return $console->command("{$expression}{$extension}", $callable, $aliases)
+            ->descriptions('', $descriptions)
+            ->defaults($defaults);
     }
 }

--- a/src/Command/CommandProvider.php
+++ b/src/Command/CommandProvider.php
@@ -37,7 +37,7 @@ class CommandProvider implements CommandGroupInterface
 
     private static function pharCommands(Container $container, Application $console): void
     {
-        if (\Phar::running() === '') {
+        if (!($_SERVER['INCLUDE_SELF_UPDATE'] ?? false) && \Phar::running() === '') {
             return;
         }
         Phar\SelfUpdateCommand::register($container, $console);

--- a/src/Command/CommandProvider.php
+++ b/src/Command/CommandProvider.php
@@ -37,7 +37,7 @@ class CommandProvider implements CommandGroupInterface
 
     private static function pharCommands(Container $container, Application $console): void
     {
-        if (!($_SERVER['INCLUDE_SELF_UPDATE'] ?? false) && \Phar::running() === '') {
+        if (\Phar::running() === '') {
             return;
         }
         Phar\SelfUpdateCommand::register($container, $console);

--- a/src/Command/Database/DumpCommand.php
+++ b/src/Command/Database/DumpCommand.php
@@ -66,7 +66,7 @@ class DumpCommand extends Command
 
     public static function register(Container $container, Application $console): void
     {
-        $console->command('database:dump [file] [-z|--gz]', self::class)
+        self::command($console, 'database:dump [file] [-z|--gz]', self::class)
             ->descriptions('Dumps the Concrete database to a file', [
                 'file' => 'Filename for the dump file',
                 '--gz' => 'Flag to gzip',

--- a/src/Command/Site/InfoCommand.php
+++ b/src/Command/Site/InfoCommand.php
@@ -31,7 +31,7 @@ class InfoCommand extends Command
      */
     public static function register(Container $container, Application $console): void
     {
-        $console->command('site:info', self::class, ['info'])
+        self::command($console, 'site:info', self::class, ['info'])
             ->descriptions('Get info about the current Concrete installation');
     }
 }

--- a/src/Command/Site/SyncCommand.php
+++ b/src/Command/Site/SyncCommand.php
@@ -55,7 +55,7 @@ class SyncCommand extends Command
 
     public static function register(Container $container, Application $console): void
     {
-        $console->command('site:sync from [--config=]', self::class)
+        self::command($console, 'site:sync from [--config=]', self::class)
             ->descriptions(
                 'Sync a remote site into this site using backups.',
                 [


### PR DESCRIPTION
This resolves #31 by giving control of default extended options to the commands themselves.